### PR TITLE
Render global properties in separate sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Fixed root command name in the help text
-Added CI pipeline & adjusted the code to pass the checks
+- Fixed root command name in the help text
+- Added CI pipeline & adjusted the code to pass the checks
+- Render separate sections for global properties like for top-level properties
 
 ## [0.0.1] - 2023-04-28
 

--- a/pkg/generate/row.go
+++ b/pkg/generate/row.go
@@ -107,7 +107,7 @@ func NewRow(schema *jsonschema.Schema, path string, name string, keyPatterns []s
 		KeyPatternMappings: keyPatternMappings,
 	}
 
-	row.Presentable = (row.Primitive || row.Path != "") && row.Name != ""
+	row.Presentable = (row.Primitive || row.Path != "" && row.Path != key.GlobalPropertyName) && row.Name != ""
 
 	if schema.Pattern != nil {
 		row.ValuePattern = schema.Pattern.String()

--- a/pkg/generate/section.go
+++ b/pkg/generate/section.go
@@ -10,15 +10,17 @@ type Section struct {
 	Name        string
 	Title       string
 	Description string
+	Path        string
 	Rows        []Row
 }
 
-func SectionFromSchema(property *jsonschema.Schema, name string) Section {
+func SectionFromSchema(property *jsonschema.Schema, path, name string) Section {
 	return Section{
 		Name:        name,
 		Title:       property.Title,
 		Description: property.Description,
-		Rows:        sortedRows(RowsFromSchema(property, "", name, []string{})),
+		Path:        path,
+		Rows:        sortedRows(RowsFromSchema(property, path, name, []string{})),
 	}
 }
 

--- a/pkg/generate/templates/section.md.tpl
+++ b/pkg/generate/templates/section.md.tpl
@@ -1,6 +1,10 @@
 ### {{.Title}}
 {{- if .Name}}
+{{- if eq .Path "global" }}
+Properties within the `.global.{{.Name}}` object
+{{- else }}
 Properties within the `.{{.Name}}` top-level object
+{{- end }}
 {{- end }}
 {{- if .Description }}
 {{ .Description }}

--- a/pkg/generate/testdata/output.txt
+++ b/pkg/generate/testdata/output.txt
@@ -9,59 +9,59 @@ Properties within the `.providerSpecific` top-level object
 | `providerSpecific.region` | **Region**|**Type:** `string`<br/>|
 
 ### Connectivity
-Properties within the `.connectivity` top-level object
+Properties within the `.global.connectivity` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `connectivity.availabilityZoneUsageLimit` | **Availability zones** - Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.|**Type:** `integer`<br/>**Default:** `3`|
-| `connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
-| `connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
-| `connectivity.bastion.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"t3.small"`|
-| `connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
-| `connectivity.bastion.subnetTags` | **Subnet tags** - Tags to filter which AWS subnets will be used for the bastion hosts.|**Type:** `array`<br/>|
-| `connectivity.bastion.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>|
-| `connectivity.bastion.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
-| `connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>|
-| `connectivity.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
-| `connectivity.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
-| `connectivity.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
-| `connectivity.containerRegistries.*[*].credentials.auth` | **Auth** - Base64-encoded string from the concatenation of the username, a colon, and the password.|**Type:** `string`<br/>|
-| `connectivity.containerRegistries.*[*].credentials.identitytoken` | **Identity token** - Used to authenticate the user and obtain an access token for the registry.|**Type:** `string`<br/>|
-| `connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
-| `connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
-| `connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
-| `connectivity.dns` | **DNS**|**Type:** `object`<br/>|
-| `connectivity.dns.additionalVpc` | **Additional VPCs** - If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.|**Type:** `array`<br/>|
-| `connectivity.dns.additionalVpc[*]` | **VPC identifier**|**Type:** `string`<br/>**Example:** `"vpc-x2aeasd1d"`<br/>**Value pattern:** `^vpc-[0-0a-zA-Z]+$`<br/>|
-| `connectivity.dns.mode` | **Mode** - Whether the Route53 hosted zone of this cluster should be public or private.|**Type:** `string`<br/>**Default:** `"public"`|
-| `connectivity.dns.resolverRulesOwnerAccount` | **Resolver rules owner** - ID of the AWS account that created the resolver rules to be associated with the workload cluster VPC.|**Type:** `string`<br/>|
-| `connectivity.network` | **Network**|**Type:** `object`<br/>|
-| `connectivity.network.podCidr` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Default:** `"100.64.0.0/12"`|
-| `connectivity.network.serviceCidr` | **Service subnet** - IPv4 address range for services, in CIDR notation.|**Type:** `string`<br/>**Default:** `"172.31.0.0/16"`|
-| `connectivity.network.vpcCidr` | **VPC subnet** - IPv4 address range to assign to this cluster's VPC, in CIDR notation.|**Type:** `string`<br/>**Default:** `"10.0.0.0/16"`|
-| `connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
-| `connectivity.proxy.enabled` | **Enable**|**Type:** `boolean`<br/>|
-| `connectivity.proxy.httpProxy` | **HTTP proxy** - To be passed to the HTTP_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
-| `connectivity.proxy.httpsProxy` | **HTTPS proxy** - To be passed to the HTTPS_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
-| `connectivity.proxy.noProxy` | **No proxy** - To be passed to the NO_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
-| `connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
-| `connectivity.subnets` | **Subnets** - Subnets are created and tagged based on this definition.|**Type:** `array`<br/>**Default:** `[{"cidrBlocks":[{"availabilityZone":"a","cidr":"10.0.0.0/20"},{"availabilityZone":"b","cidr":"10.0.16.0/20"},{"availabilityZone":"c","cidr":"10.0.32.0/20"}],"isPublic":true},{"cidrBlocks":[{"availabilityZone":"a","cidr":"10.0.64.0/18"},{"availabilityZone":"b","cidr":"10.0.128.0/18"},{"availabilityZone":"c","cidr":"10.0.192.0/18"}],"isPublic":false}]`|
-| `connectivity.subnets[*]` | **Subnet**|**Type:** `object`<br/>|
-| `connectivity.subnets[*].cidrBlocks` | **Network**|**Type:** `array`<br/>|
-| `connectivity.subnets[*].cidrBlocks[*]` |**None**|**Type:** `object`<br/>|
-| `connectivity.subnets[*].cidrBlocks[*].availabilityZone` | **Availability zone**|**Type:** `string`<br/>**Example:** `"a"`<br/>|
-| `connectivity.subnets[*].cidrBlocks[*].cidr` | **Address range** - IPv4 address range, in CIDR notation.|**Type:** `string`<br/>|
-| `connectivity.subnets[*].cidrBlocks[*].tags` | **Tags** - AWS resource tags to assign to this subnet.|**Type:** `object`<br/>|
-| `connectivity.subnets[*].cidrBlocks[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
-| `connectivity.subnets[*].isPublic` | **Public**|**Type:** `boolean`<br/>|
-| `connectivity.subnets[*].tags` | **Tags** - AWS resource tags to assign to this CIDR block.|**Type:** `object`<br/>|
-| `connectivity.subnets[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
-| `connectivity.topology` | **Topology** - Networking architecture between management cluster and workload cluster.|**Type:** `object`<br/>|
-| `connectivity.topology.mode` | **Mode** - Valid values: GiantSwarmManaged, UserManaged, None.|**Type:** `string`<br/>**Default:** `"None"`|
-| `connectivity.topology.prefixListId` | **Prefix list ID** - ID of the managed prefix list to use when the topology mode is set to 'UserManaged'.|**Type:** `string`<br/>|
-| `connectivity.topology.transitGatewayId` | **Transit gateway ID** - If the topology mode is set to 'UserManaged', this can be used to specify the transit gateway to use.|**Type:** `string`<br/>|
-| `connectivity.vpcEndpointMode` | **VPC endpoint mode** - Who is reponsible for creation and management of VPC endpoints.|**Type:** `string`<br/>**Default:** `"GiantSwarmManaged"`|
-| `connectivity.vpcMode` | **VPC mode** - Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).|**Type:** `string`<br/>**Default:** `"public"`|
+| `global.connectivity.availabilityZoneUsageLimit` | **Availability zones** - Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.|**Type:** `integer`<br/>**Default:** `3`|
+| `global.connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
+| `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
+| `global.connectivity.bastion.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"t3.small"`|
+| `global.connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
+| `global.connectivity.bastion.subnetTags` | **Subnet tags** - Tags to filter which AWS subnets will be used for the bastion hosts.|**Type:** `array`<br/>|
+| `global.connectivity.bastion.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>|
+| `global.connectivity.bastion.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
+| `global.connectivity.containerRegistries` | **Container registries** - Endpoints and credentials configuration for container registries.|**Type:** `object`<br/>|
+| `global.connectivity.containerRegistries.*` | **Registries** - Container registries and mirrors|**Type:** `array`<br/>|
+| `global.connectivity.containerRegistries.*[*]` | **Registry**|**Type:** `object`<br/>|
+| `global.connectivity.containerRegistries.*[*].credentials` | **Credentials**|**Type:** `object`<br/>|
+| `global.connectivity.containerRegistries.*[*].credentials.auth` | **Auth** - Base64-encoded string from the concatenation of the username, a colon, and the password.|**Type:** `string`<br/>|
+| `global.connectivity.containerRegistries.*[*].credentials.identitytoken` | **Identity token** - Used to authenticate the user and obtain an access token for the registry.|**Type:** `string`<br/>|
+| `global.connectivity.containerRegistries.*[*].credentials.password` | **Password** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
+| `global.connectivity.containerRegistries.*[*].credentials.username` | **Username** - Used to authenticate for the registry with username/password.|**Type:** `string`<br/>|
+| `global.connectivity.containerRegistries.*[*].endpoint` | **Endpoint** - Endpoint for the container registry.|**Type:** `string`<br/>|
+| `global.connectivity.dns` | **DNS**|**Type:** `object`<br/>|
+| `global.connectivity.dns.additionalVpc` | **Additional VPCs** - If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.|**Type:** `array`<br/>|
+| `global.connectivity.dns.additionalVpc[*]` | **VPC identifier**|**Type:** `string`<br/>**Example:** `"vpc-x2aeasd1d"`<br/>**Value pattern:** `^vpc-[0-0a-zA-Z]+$`<br/>|
+| `global.connectivity.dns.mode` | **Mode** - Whether the Route53 hosted zone of this cluster should be public or private.|**Type:** `string`<br/>**Default:** `"public"`|
+| `global.connectivity.dns.resolverRulesOwnerAccount` | **Resolver rules owner** - ID of the AWS account that created the resolver rules to be associated with the workload cluster VPC.|**Type:** `string`<br/>|
+| `global.connectivity.network` | **Network**|**Type:** `object`<br/>|
+| `global.connectivity.network.podCidr` | **Pod subnet** - IPv4 address range for pods, in CIDR notation.|**Type:** `string`<br/>**Default:** `"100.64.0.0/12"`|
+| `global.connectivity.network.serviceCidr` | **Service subnet** - IPv4 address range for services, in CIDR notation.|**Type:** `string`<br/>**Default:** `"172.31.0.0/16"`|
+| `global.connectivity.network.vpcCidr` | **VPC subnet** - IPv4 address range to assign to this cluster's VPC, in CIDR notation.|**Type:** `string`<br/>**Default:** `"10.0.0.0/16"`|
+| `global.connectivity.proxy` | **Proxy** - Whether/how outgoing traffic is routed through proxy servers.|**Type:** `object`<br/>|
+| `global.connectivity.proxy.enabled` | **Enable**|**Type:** `boolean`<br/>|
+| `global.connectivity.proxy.httpProxy` | **HTTP proxy** - To be passed to the HTTP_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
+| `global.connectivity.proxy.httpsProxy` | **HTTPS proxy** - To be passed to the HTTPS_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
+| `global.connectivity.proxy.noProxy` | **No proxy** - To be passed to the NO_PROXY environment variable in all hosts.|**Type:** `string`<br/>|
+| `global.connectivity.sshSsoPublicKey` | **SSH public key for single sign-on**|**Type:** `string`<br/>**Default:** `"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io"`|
+| `global.connectivity.subnets` | **Subnets** - Subnets are created and tagged based on this definition.|**Type:** `array`<br/>**Default:** `[{"cidrBlocks":[{"availabilityZone":"a","cidr":"10.0.0.0/20"},{"availabilityZone":"b","cidr":"10.0.16.0/20"},{"availabilityZone":"c","cidr":"10.0.32.0/20"}],"isPublic":true},{"cidrBlocks":[{"availabilityZone":"a","cidr":"10.0.64.0/18"},{"availabilityZone":"b","cidr":"10.0.128.0/18"},{"availabilityZone":"c","cidr":"10.0.192.0/18"}],"isPublic":false}]`|
+| `global.connectivity.subnets[*]` | **Subnet**|**Type:** `object`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks` | **Network**|**Type:** `array`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks[*]` |**None**|**Type:** `object`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks[*].availabilityZone` | **Availability zone**|**Type:** `string`<br/>**Example:** `"a"`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks[*].cidr` | **Address range** - IPv4 address range, in CIDR notation.|**Type:** `string`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks[*].tags` | **Tags** - AWS resource tags to assign to this subnet.|**Type:** `object`<br/>|
+| `global.connectivity.subnets[*].cidrBlocks[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
+| `global.connectivity.subnets[*].isPublic` | **Public**|**Type:** `boolean`<br/>|
+| `global.connectivity.subnets[*].tags` | **Tags** - AWS resource tags to assign to this CIDR block.|**Type:** `object`<br/>|
+| `global.connectivity.subnets[*].tags.*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
+| `global.connectivity.topology` | **Topology** - Networking architecture between management cluster and workload cluster.|**Type:** `object`<br/>|
+| `global.connectivity.topology.mode` | **Mode** - Valid values: GiantSwarmManaged, UserManaged, None.|**Type:** `string`<br/>**Default:** `"None"`|
+| `global.connectivity.topology.prefixListId` | **Prefix list ID** - ID of the managed prefix list to use when the topology mode is set to 'UserManaged'.|**Type:** `string`<br/>|
+| `global.connectivity.topology.transitGatewayId` | **Transit gateway ID** - If the topology mode is set to 'UserManaged', this can be used to specify the transit gateway to use.|**Type:** `string`<br/>|
+| `global.connectivity.vpcEndpointMode` | **VPC endpoint mode** - Who is reponsible for creation and management of VPC endpoints.|**Type:** `string`<br/>**Default:** `"GiantSwarmManaged"`|
+| `global.connectivity.vpcMode` | **VPC mode** - Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).|**Type:** `string`<br/>**Default:** `"public"`|
 
 ### Control plane
 Properties within the `.controlPlane` top-level object
@@ -132,13 +132,13 @@ Properties within the `.kubectlImage` top-level object
 | `kubectlImage.tag` | **Tag**|**Type:** `string`<br/>**Default:** `"1.23.5"`|
 
 ### Metadata
-Properties within the `.metadata` top-level object
+Properties within the `.global.metadata` object
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
-| `metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
-| `metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
-| `metadata.organization` | **Organization**|**Type:** `string`<br/>|
+| `global.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
+| `global.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
+| `global.metadata.organization` | **Organization**|**Type:** `string`<br/>|
 
 ### Node pools
 Properties within the `.nodePools` top-level object
@@ -163,12 +163,17 @@ Properties within the `.nodePools` top-level object
 | `nodePools.PATTERN.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `nodePools.PATTERN.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
 
+### Other global
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
+
 ### Other
 
 | **Property** | **Description** | **More Details** |
 | :----------- | :-------------- | :--------------- |
 | `baseDomain` | **Base DNS domain**|**Type:** `string`<br/>|
 | `cluster-shared` | **Library chart**|**Type:** `object`<br/>|
-| `managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
 | `provider` | **Cluster API provider name**|**Type:** `string`<br/>|
 

--- a/pkg/generate/testdata/schema.json
+++ b/pkg/generate/testdata/schema.json
@@ -101,334 +101,6 @@
       "title": "Library chart",
       "type": "object"
     },
-    "connectivity": {
-      "properties": {
-        "availabilityZoneUsageLimit": {
-          "default": 3,
-          "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
-          "title": "Availability zones",
-          "type": "integer"
-        },
-        "bastion": {
-          "properties": {
-            "enabled": {
-              "default": true,
-              "title": "Enable",
-              "type": "boolean"
-            },
-            "instanceType": {
-              "default": "t3.small",
-              "title": "EC2 instance type",
-              "type": "string"
-            },
-            "replicas": {
-              "default": 1,
-              "title": "Number of hosts",
-              "type": "integer"
-            },
-            "subnetTags": {
-              "description": "Tags to filter which AWS subnets will be used for the bastion hosts.",
-              "items": {
-                "additionalProperties": {
-                  "$ref": "#/$defs/awsResourceTagValue"
-                },
-                "title": "Subnet tag",
-                "type": "object"
-              },
-              "title": "Subnet tags",
-              "type": "array"
-            }
-          },
-          "title": "Bastion host",
-          "type": "object"
-        },
-        "containerRegistries": {
-          "additionalProperties": {
-            "description": "Container registries and mirrors",
-            "items": {
-              "properties": {
-                "credentials": {
-                  "properties": {
-                    "auth": {
-                      "description": "Base64-encoded string from the concatenation of the username, a colon, and the password.",
-                      "title": "Auth",
-                      "type": "string"
-                    },
-                    "identitytoken": {
-                      "description": "Used to authenticate the user and obtain an access token for the registry.",
-                      "title": "Identity token",
-                      "type": "string"
-                    },
-                    "password": {
-                      "description": "Used to authenticate for the registry with username/password.",
-                      "title": "Password",
-                      "type": "string"
-                    },
-                    "username": {
-                      "description": "Used to authenticate for the registry with username/password.",
-                      "title": "Username",
-                      "type": "string"
-                    }
-                  },
-                  "title": "Credentials",
-                  "type": "object"
-                },
-                "endpoint": {
-                  "description": "Endpoint for the container registry.",
-                  "title": "Endpoint",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "endpoint"
-              ],
-              "title": "Registry",
-              "type": "object"
-            },
-            "title": "Registries",
-            "type": "array"
-          },
-          "description": "Endpoints and credentials configuration for container registries.",
-          "title": "Container registries",
-          "type": "object"
-        },
-        "dns": {
-          "properties": {
-            "additionalVpc": {
-              "description": "If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.",
-              "items": {
-                "examples": [
-                  "vpc-x2aeasd1d"
-                ],
-                "pattern": "^vpc-[0-0a-zA-Z]+$",
-                "title": "VPC identifier",
-                "type": "string"
-              },
-              "title": "Additional VPCs",
-              "type": "array"
-            },
-            "mode": {
-              "default": "public",
-              "description": "Whether the Route53 hosted zone of this cluster should be public or private.",
-              "enum": [
-                "public",
-                "private"
-              ],
-              "title": "Mode",
-              "type": "string"
-            },
-            "resolverRulesOwnerAccount": {
-              "description": "ID of the AWS account that created the resolver rules to be associated with the workload cluster VPC.",
-              "oneOf": [
-                {
-                  "pattern": "^\\d{12}$"
-                },
-                {
-                  "const": ""
-                }
-              ],
-              "title": "Resolver rules owner",
-              "type": "string"
-            }
-          },
-          "title": "DNS",
-          "type": "object"
-        },
-        "network": {
-          "properties": {
-            "podCidr": {
-              "default": "100.64.0.0/12",
-              "description": "IPv4 address range for pods, in CIDR notation.",
-              "title": "Pod subnet",
-              "type": "string"
-            },
-            "serviceCidr": {
-              "default": "172.31.0.0/16",
-              "description": "IPv4 address range for services, in CIDR notation.",
-              "title": "Service subnet",
-              "type": "string"
-            },
-            "vpcCidr": {
-              "default": "10.0.0.0/16",
-              "description": "IPv4 address range to assign to this cluster's VPC, in CIDR notation.",
-              "title": "VPC subnet",
-              "type": "string"
-            }
-          },
-          "title": "Network",
-          "type": "object"
-        },
-        "proxy": {
-          "description": "Whether/how outgoing traffic is routed through proxy servers.",
-          "properties": {
-            "enabled": {
-              "title": "Enable",
-              "type": "boolean"
-            },
-            "httpProxy": {
-              "description": "To be passed to the HTTP_PROXY environment variable in all hosts.",
-              "title": "HTTP proxy",
-              "type": "string"
-            },
-            "httpsProxy": {
-              "description": "To be passed to the HTTPS_PROXY environment variable in all hosts.",
-              "title": "HTTPS proxy",
-              "type": "string"
-            },
-            "noProxy": {
-              "description": "To be passed to the NO_PROXY environment variable in all hosts.",
-              "title": "No proxy",
-              "type": "string"
-            }
-          },
-          "title": "Proxy",
-          "type": "object"
-        },
-        "sshSsoPublicKey": {
-          "default": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io",
-          "title": "SSH public key for single sign-on",
-          "type": "string"
-        },
-        "subnets": {
-          "default": [
-            {
-              "cidrBlocks": [
-                {
-                  "availabilityZone": "a",
-                  "cidr": "10.0.0.0/20"
-                },
-                {
-                  "availabilityZone": "b",
-                  "cidr": "10.0.16.0/20"
-                },
-                {
-                  "availabilityZone": "c",
-                  "cidr": "10.0.32.0/20"
-                }
-              ],
-              "isPublic": true
-            },
-            {
-              "cidrBlocks": [
-                {
-                  "availabilityZone": "a",
-                  "cidr": "10.0.64.0/18"
-                },
-                {
-                  "availabilityZone": "b",
-                  "cidr": "10.0.128.0/18"
-                },
-                {
-                  "availabilityZone": "c",
-                  "cidr": "10.0.192.0/18"
-                }
-              ],
-              "isPublic": false
-            }
-          ],
-          "description": "Subnets are created and tagged based on this definition.",
-          "items": {
-            "properties": {
-              "cidrBlocks": {
-                "items": {
-                  "properties": {
-                    "availabilityZone": {
-                      "examples": [
-                        "a"
-                      ],
-                      "title": "Availability zone",
-                      "type": "string"
-                    },
-                    "cidr": {
-                      "description": "IPv4 address range, in CIDR notation.",
-                      "title": "Address range",
-                      "type": "string"
-                    },
-                    "tags": {
-                      "additionalProperties": {
-                        "$ref": "#/$defs/awsResourceTagValue"
-                      },
-                      "description": "AWS resource tags to assign to this subnet.",
-                      "title": "Tags",
-                      "type": "object"
-                    }
-                  },
-                  "type": "object"
-                },
-                "title": "Network",
-                "type": "array"
-              },
-              "isPublic": {
-                "title": "Public",
-                "type": "boolean"
-              },
-              "tags": {
-                "additionalProperties": {
-                  "$ref": "#/$defs/awsResourceTagValue"
-                },
-                "description": "AWS resource tags to assign to this CIDR block.",
-                "title": "Tags",
-                "type": "object"
-              }
-            },
-            "title": "Subnet",
-            "type": "object"
-          },
-          "title": "Subnets",
-          "type": "array"
-        },
-        "topology": {
-          "description": "Networking architecture between management cluster and workload cluster.",
-          "properties": {
-            "mode": {
-              "default": "None",
-              "description": "Valid values: GiantSwarmManaged, UserManaged, None.",
-              "enum": [
-                "None",
-                "GiantSwarmManaged",
-                "UserManaged"
-              ],
-              "title": "Mode",
-              "type": "string"
-            },
-            "prefixListId": {
-              "description": "ID of the managed prefix list to use when the topology mode is set to 'UserManaged'.",
-              "title": "Prefix list ID",
-              "type": "string"
-            },
-            "transitGatewayId": {
-              "description": "If the topology mode is set to 'UserManaged', this can be used to specify the transit gateway to use.",
-              "title": "Transit gateway ID",
-              "type": "string"
-            }
-          },
-          "title": "Topology",
-          "type": "object"
-        },
-        "vpcEndpointMode": {
-          "default": "GiantSwarmManaged",
-          "description": "Who is reponsible for creation and management of VPC endpoints.",
-          "enum": [
-            "GiantSwarmManaged",
-            "UserManaged"
-          ],
-          "title": "VPC endpoint mode",
-          "type": "string"
-        },
-        "vpcMode": {
-          "default": "public",
-          "description": "Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).",
-          "enum": [
-            "public",
-            "private"
-          ],
-          "title": "VPC mode",
-          "type": "string"
-        }
-      },
-      "title": "Connectivity",
-      "type": "object"
-    },
     "controlPlane": {
       "properties": {
         "apiMode": {
@@ -575,6 +247,365 @@
       "title": "Default node pool",
       "type": "object"
     },
+    "global": {
+      "type": "object",
+      "title": "Global",
+      "properties": {
+        "connectivity": {
+          "properties": {
+            "availabilityZoneUsageLimit": {
+              "default": 3,
+              "description": "Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.",
+              "title": "Availability zones",
+              "type": "integer"
+            },
+            "bastion": {
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "title": "Enable",
+                  "type": "boolean"
+                },
+                "instanceType": {
+                  "default": "t3.small",
+                  "title": "EC2 instance type",
+                  "type": "string"
+                },
+                "replicas": {
+                  "default": 1,
+                  "title": "Number of hosts",
+                  "type": "integer"
+                },
+                "subnetTags": {
+                  "description": "Tags to filter which AWS subnets will be used for the bastion hosts.",
+                  "items": {
+                    "additionalProperties": {
+                      "$ref": "#/$defs/awsResourceTagValue"
+                    },
+                    "title": "Subnet tag",
+                    "type": "object"
+                  },
+                  "title": "Subnet tags",
+                  "type": "array"
+                }
+              },
+              "title": "Bastion host",
+              "type": "object"
+            },
+            "containerRegistries": {
+              "additionalProperties": {
+                "description": "Container registries and mirrors",
+                "items": {
+                  "properties": {
+                    "credentials": {
+                      "properties": {
+                        "auth": {
+                          "description": "Base64-encoded string from the concatenation of the username, a colon, and the password.",
+                          "title": "Auth",
+                          "type": "string"
+                        },
+                        "identitytoken": {
+                          "description": "Used to authenticate the user and obtain an access token for the registry.",
+                          "title": "Identity token",
+                          "type": "string"
+                        },
+                        "password": {
+                          "description": "Used to authenticate for the registry with username/password.",
+                          "title": "Password",
+                          "type": "string"
+                        },
+                        "username": {
+                          "description": "Used to authenticate for the registry with username/password.",
+                          "title": "Username",
+                          "type": "string"
+                        }
+                      },
+                      "title": "Credentials",
+                      "type": "object"
+                    },
+                    "endpoint": {
+                      "description": "Endpoint for the container registry.",
+                      "title": "Endpoint",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "endpoint"
+                  ],
+                  "title": "Registry",
+                  "type": "object"
+                },
+                "title": "Registries",
+                "type": "array"
+              },
+              "description": "Endpoints and credentials configuration for container registries.",
+              "title": "Container registries",
+              "type": "object"
+            },
+            "dns": {
+              "properties": {
+                "additionalVpc": {
+                  "description": "If DNS mode is 'private', the VPCs specified here will be assigned to the private hosted zone.",
+                  "items": {
+                    "examples": [
+                      "vpc-x2aeasd1d"
+                    ],
+                    "pattern": "^vpc-[0-0a-zA-Z]+$",
+                    "title": "VPC identifier",
+                    "type": "string"
+                  },
+                  "title": "Additional VPCs",
+                  "type": "array"
+                },
+                "mode": {
+                  "default": "public",
+                  "description": "Whether the Route53 hosted zone of this cluster should be public or private.",
+                  "enum": [
+                    "public",
+                    "private"
+                  ],
+                  "title": "Mode",
+                  "type": "string"
+                },
+                "resolverRulesOwnerAccount": {
+                  "description": "ID of the AWS account that created the resolver rules to be associated with the workload cluster VPC.",
+                  "oneOf": [
+                    {
+                      "pattern": "^\\d{12}$"
+                    },
+                    {
+                      "const": ""
+                    }
+                  ],
+                  "title": "Resolver rules owner",
+                  "type": "string"
+                }
+              },
+              "title": "DNS",
+              "type": "object"
+            },
+            "network": {
+              "properties": {
+                "podCidr": {
+                  "default": "100.64.0.0/12",
+                  "description": "IPv4 address range for pods, in CIDR notation.",
+                  "title": "Pod subnet",
+                  "type": "string"
+                },
+                "serviceCidr": {
+                  "default": "172.31.0.0/16",
+                  "description": "IPv4 address range for services, in CIDR notation.",
+                  "title": "Service subnet",
+                  "type": "string"
+                },
+                "vpcCidr": {
+                  "default": "10.0.0.0/16",
+                  "description": "IPv4 address range to assign to this cluster's VPC, in CIDR notation.",
+                  "title": "VPC subnet",
+                  "type": "string"
+                }
+              },
+              "title": "Network",
+              "type": "object"
+            },
+            "proxy": {
+              "description": "Whether/how outgoing traffic is routed through proxy servers.",
+              "properties": {
+                "enabled": {
+                  "title": "Enable",
+                  "type": "boolean"
+                },
+                "httpProxy": {
+                  "description": "To be passed to the HTTP_PROXY environment variable in all hosts.",
+                  "title": "HTTP proxy",
+                  "type": "string"
+                },
+                "httpsProxy": {
+                  "description": "To be passed to the HTTPS_PROXY environment variable in all hosts.",
+                  "title": "HTTPS proxy",
+                  "type": "string"
+                },
+                "noProxy": {
+                  "description": "To be passed to the NO_PROXY environment variable in all hosts.",
+                  "title": "No proxy",
+                  "type": "string"
+                }
+              },
+              "title": "Proxy",
+              "type": "object"
+            },
+            "sshSsoPublicKey": {
+              "default": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM4cvZ01fLmO9cJbWUj7sfF+NhECgy+Cl0bazSrZX7sU vault-ca@vault.operations.giantswarm.io",
+              "title": "SSH public key for single sign-on",
+              "type": "string"
+            },
+            "subnets": {
+              "default": [
+                {
+                  "cidrBlocks": [
+                    {
+                      "availabilityZone": "a",
+                      "cidr": "10.0.0.0/20"
+                    },
+                    {
+                      "availabilityZone": "b",
+                      "cidr": "10.0.16.0/20"
+                    },
+                    {
+                      "availabilityZone": "c",
+                      "cidr": "10.0.32.0/20"
+                    }
+                  ],
+                  "isPublic": true
+                },
+                {
+                  "cidrBlocks": [
+                    {
+                      "availabilityZone": "a",
+                      "cidr": "10.0.64.0/18"
+                    },
+                    {
+                      "availabilityZone": "b",
+                      "cidr": "10.0.128.0/18"
+                    },
+                    {
+                      "availabilityZone": "c",
+                      "cidr": "10.0.192.0/18"
+                    }
+                  ],
+                  "isPublic": false
+                }
+              ],
+              "description": "Subnets are created and tagged based on this definition.",
+              "items": {
+                "properties": {
+                  "cidrBlocks": {
+                    "items": {
+                      "properties": {
+                        "availabilityZone": {
+                          "examples": [
+                            "a"
+                          ],
+                          "title": "Availability zone",
+                          "type": "string"
+                        },
+                        "cidr": {
+                          "description": "IPv4 address range, in CIDR notation.",
+                          "title": "Address range",
+                          "type": "string"
+                        },
+                        "tags": {
+                          "additionalProperties": {
+                            "$ref": "#/$defs/awsResourceTagValue"
+                          },
+                          "description": "AWS resource tags to assign to this subnet.",
+                          "title": "Tags",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "title": "Network",
+                    "type": "array"
+                  },
+                  "isPublic": {
+                    "title": "Public",
+                    "type": "boolean"
+                  },
+                  "tags": {
+                    "additionalProperties": {
+                      "$ref": "#/$defs/awsResourceTagValue"
+                    },
+                    "description": "AWS resource tags to assign to this CIDR block.",
+                    "title": "Tags",
+                    "type": "object"
+                  }
+                },
+                "title": "Subnet",
+                "type": "object"
+              },
+              "title": "Subnets",
+              "type": "array"
+            },
+            "topology": {
+              "description": "Networking architecture between management cluster and workload cluster.",
+              "properties": {
+                "mode": {
+                  "default": "None",
+                  "description": "Valid values: GiantSwarmManaged, UserManaged, None.",
+                  "enum": [
+                    "None",
+                    "GiantSwarmManaged",
+                    "UserManaged"
+                  ],
+                  "title": "Mode",
+                  "type": "string"
+                },
+                "prefixListId": {
+                  "description": "ID of the managed prefix list to use when the topology mode is set to 'UserManaged'.",
+                  "title": "Prefix list ID",
+                  "type": "string"
+                },
+                "transitGatewayId": {
+                  "description": "If the topology mode is set to 'UserManaged', this can be used to specify the transit gateway to use.",
+                  "title": "Transit gateway ID",
+                  "type": "string"
+                }
+              },
+              "title": "Topology",
+              "type": "object"
+            },
+            "vpcEndpointMode": {
+              "default": "GiantSwarmManaged",
+              "description": "Who is reponsible for creation and management of VPC endpoints.",
+              "enum": [
+                "GiantSwarmManaged",
+                "UserManaged"
+              ],
+              "title": "VPC endpoint mode",
+              "type": "string"
+            },
+            "vpcMode": {
+              "default": "public",
+              "description": "Whether the cluser's VPC is created with public, internet facing resources (public subnets, NAT gateway) or not (private).",
+              "enum": [
+                "public",
+                "private"
+              ],
+              "title": "VPC mode",
+              "type": "string"
+            }
+          },
+          "title": "Connectivity",
+          "type": "object"
+        },
+        "managementCluster": {
+          "description": "Name of the Cluster API cluster managing this workload cluster.",
+          "title": "Management cluster",
+          "type": "string"
+        },
+        "metadata": {
+          "properties": {
+            "description": {
+              "description": "User-friendly description of the cluster's purpose.",
+              "title": "Cluster description",
+              "type": "string"
+            },
+            "name": {
+              "description": "Unique identifier, cannot be changed after creation.",
+              "title": "Cluster name",
+              "type": "string"
+            },
+            "organization": {
+              "title": "Organization",
+              "type": "string"
+            }
+          },
+          "title": "Metadata",
+          "type": "object"
+        }
+      }
+    },
     "internal": {
       "description": "For Giant Swarm internal use only, not stable, or not supported by UIs.",
       "properties": {
@@ -614,31 +645,6 @@
         }
       },
       "title": "Kubectl image",
-      "type": "object"
-    },
-    "managementCluster": {
-      "description": "Name of the Cluster API cluster managing this workload cluster.",
-      "title": "Management cluster",
-      "type": "string"
-    },
-    "metadata": {
-      "properties": {
-        "description": {
-          "description": "User-friendly description of the cluster's purpose.",
-          "title": "Cluster description",
-          "type": "string"
-        },
-        "name": {
-          "description": "Unique identifier, cannot be changed after creation.",
-          "title": "Cluster name",
-          "type": "string"
-        },
-        "organization": {
-          "title": "Organization",
-          "type": "string"
-        }
-      },
-      "title": "Metadata",
       "type": "object"
     },
     "nodePools": {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -3,13 +3,15 @@ package key
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 const (
-	ItemNameSuffix    = "[*]"
-	OtherSectionTitle = "Other"
+	GlobalPropertyName = "global"
+	ItemNameSuffix     = "[*]"
+	OtherSectionTitle  = "Other"
 )
 
 func NameFromPattern(pattern *regexp.Regexp, patterns []string, defaultName string) string {
@@ -57,7 +59,7 @@ func SchemaIsPrimitive(schema *jsonschema.Schema) bool {
 
 func SchemaIsPresentable(schema *jsonschema.Schema) bool {
 	return SchemaIsPrimitive(schema) ||
-		schema.Title != "" ||
+		schema.Title != "" && strings.ToLower(schema.Title) != GlobalPropertyName ||
 		schema.Items2020 != nil ||
 		(schema.Items != nil && schema.Items != false) ||
 		(schema.AdditionalProperties != nil && schema.AdditionalProperties != false)


### PR DESCRIPTION
### What does this PR do?

We have ported all provider-independent Cluster API resources to cluster chart, which was phase 1 of restructuring of cluster- apps, see https://github.com/giantswarm/roadmap/issues/2742 for more details. Now we want to use `cluster` chart in all `cluster-<provider>` apps and remove all provider-independent Cluster API resources from `cluster-<provider>` apps.

In order to do so, first we have to refactor `cluster-<provider>` apps Helm values, so that `cluster` chart can read provider-independent values it needs. For that, we have to move current top-level properties to be under `Values.global`.

When current root-level properties are moved to be under `Values.global`, the schema docs rendering puts all global properties into a single section, which is not well readable. Properties being under `.Values.global` is a Helm implementation detail that we need in order to read Helm values in provider-independent `cluster` subchart (where all provider-independent Cluster API resources are rendered), and those global properties should be treated as root-level properties.

This PR adds support for rendering of global properties as separate sections, like they were root-level properties.

### What is the effect of this change to users?

Global properties, which are shared across parent chart and subcharts, are documented separately in its own section, rather than having a single "Global" section with all properties merged together.

### How does it look like?

Before:

```Markdown
### Global
Properties within the `.global` top-level object

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.connectivity.availabilityZoneUsageLimit` | **Availability zones** - Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.|**Type:** `integer`<br/>**Default:** `3`|
| `global.connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
| `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
| `global.connectivity.bastion.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"t3.small"`|
| `global.connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
| `global.connectivity.bastion.subnetTags` | **Subnet tags** - Tags to filter which AWS subnets will be used for the bastion hosts.|**Type:** `array`<br/>|
| `global.connectivity.bastion.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>|
| `global.connectivity.bastion.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|
| `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
| `global.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
| `global.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
| `global.metadata.organization` | **Organization**|**Type:** `string`<br/>|
```

After:

```Markdown
### Connectivity
Properties within the `.global.connectivity` object

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.connectivity.availabilityZoneUsageLimit` | **Availability zones** - Maximum number of availability zones (AZ) that should be used in a region. If a region has more than this number of AZs then this number of AZs will be picked randomly when creating subnets.|**Type:** `integer`<br/>**Default:** `3`|
| `global.connectivity.bastion` | **Bastion host**|**Type:** `object`<br/>|
| `global.connectivity.bastion.enabled` | **Enable**|**Type:** `boolean`<br/>**Default:** `true`|
| `global.connectivity.bastion.instanceType` | **EC2 instance type**|**Type:** `string`<br/>**Default:** `"t3.small"`|
| `global.connectivity.bastion.replicas` | **Number of hosts**|**Type:** `integer`<br/>**Default:** `1`|
| `global.connectivity.bastion.subnetTags` | **Subnet tags** - Tags to filter which AWS subnets will be used for the bastion hosts.|**Type:** `array`<br/>|
| `global.connectivity.bastion.subnetTags[*]` | **Subnet tag**|**Type:** `object`<br/>|
| `global.connectivity.bastion.subnetTags[*].*` | **Tag value**|**Type:** `string`<br/>**Value pattern:** `^[ a-zA-Z0-9\._:/=+-@]+$`<br/>|

### Metadata
Properties within the `.global.metadata` object

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
| `global.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
| `global.metadata.organization` | **Organization**|**Type:** `string`<br/>|

### Other global

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.managementCluster` | **Management cluster** - Name of the Cluster API cluster managing this workload cluster.|**Type:** `string`<br/>|
```

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/2739
- https://github.com/giantswarm/roadmap/issues/2954
- https://github.com/giantswarm/cluster-aws/pull/413
- https://github.com/giantswarm/cluster-aws/pull/414
- https://github.com/giantswarm/cluster-aws/pull/415
- https://github.com/giantswarm/cluster-aws/pull/416

### What is needed from the reviewers?

Feedback and review.

### Do the docs need to be updated?

I don't think so.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
