### PR TITLE
Fix rendering of global properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ sample.json
 test_readme.md
 
 schemadocs
+schemadocs-v*-*-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed rendering of global properties
+
 ## [0.0.2] - 2023-11-16
 
 ### Fixed

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -32,14 +32,14 @@ func sectionsFromSchema(schema *jsonschema.Schema, path string) []Section {
 
 	if key.SchemaIsPrimitive(schema) {
 		otherSectionRows = append(otherSectionRows, RowsFromSchema(schema, path, schema.Title, []string{})...)
-	} else if key.SchemaIsPresentable(schema) {
+	} else if key.SchemaIsPresentable(schema) && path != key.GlobalPropertyName {
 		sections = append(sections, SectionFromSchema(schema, path, schema.Title))
 	} else {
 		for name, property := range schema.Properties {
 			if key.SchemaIsPrimitive(property) {
 				otherSectionRows = append(otherSectionRows, RowsFromSchema(property, path, name, []string{})...)
 			} else if name == key.GlobalPropertyName {
-				globalSections := sectionsFromSchema(property, name)
+				globalSections := sectionsFromSchema(property, key.GlobalPropertyName)
 				sections = append(sections, globalSections...)
 			} else {
 				sections = append(sections, SectionFromSchema(property, path, name))

--- a/pkg/generate/testdata/schema.json
+++ b/pkg/generate/testdata/schema.json
@@ -249,7 +249,7 @@
     },
     "global": {
       "type": "object",
-      "title": "Global",
+      "title": "Global properties",
       "properties": {
         "connectivity": {
           "properties": {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,8 +2,9 @@ package key
 
 import (
 	"fmt"
-	"github.com/santhosh-tekuri/jsonschema/v5"
 	"regexp"
+
+	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 const (

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,10 +2,8 @@ package key
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
-
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	"regexp"
 )
 
 const (
@@ -59,7 +57,7 @@ func SchemaIsPrimitive(schema *jsonschema.Schema) bool {
 
 func SchemaIsPresentable(schema *jsonschema.Schema) bool {
 	return SchemaIsPrimitive(schema) ||
-		schema.Title != "" && strings.ToLower(schema.Title) != GlobalPropertyName ||
+		schema.Title != "" ||
 		schema.Items2020 != nil ||
 		(schema.Items != nil && schema.Items != false) ||
 		(schema.AdditionalProperties != nil && schema.AdditionalProperties != false)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the rendering of global properties. The bug surfaced when global property had a title "Global properties" (in cluster-aws where this was initially supposed to be used) instead of just "Global".

### What is the effect of this change to users?

Fixed JSON schema docs rendering.

### How does it look like?

Before:

```Markdown
### Global properties
Properties within the `.global.Global properties` object
Properties that are available to all charts and subcharts.

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.Global properties.metadata` | **Metadata**|**Type:** `object`<br/>|
| `global.Global properties.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
| `global.Global properties.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
| `global.Global properties.metadata.organization` | **Organization**|**Type:** `string`<br/>|
| `global.Global properties.metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
```

After:

```Markdown
### Metadata
Properties within the `.global.metadata` object

| **Property** | **Description** | **More Details** |
| :----------- | :-------------- | :--------------- |
| `global.metadata.description` | **Cluster description** - User-friendly description of the cluster's purpose.|**Type:** `string`<br/>|
| `global.metadata.name` | **Cluster name** - Unique identifier, cannot be changed after creation.|**Type:** `string`<br/>|
| `global.metadata.organization` | **Organization**|**Type:** `string`<br/>|
| `global.metadata.servicePriority` | **Service priority** - The relative importance of this cluster.|**Type:** `string`<br/>**Default:** `"highest"`|
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
