### PR TITLE
Sort sections by title-then-path to fix unstable order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sort sections by title-then-path to fix unstable order
+
 ## [0.0.3] - 2023-11-17
 
 ### Fixed

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -47,9 +47,16 @@ func sectionsFromSchema(schema *jsonschema.Schema, path string) []Section {
 		}
 	}
 
-	sort.SliceStable(sections, func(i, j int) bool { return sections[i].Title < sections[j].Title })
+	sort.SliceStable(sections, func(i, j int) bool {
+		if sections[i].Title == sections[j].Title {
+			return sections[i].Path < sections[j].Path
+		}
+		return sections[i].Title < sections[j].Title
+	})
 
 	if len(otherSectionRows) > 0 {
+		otherSectionRows = sortedRows(otherSectionRows)
+
 		var otherSectionTitle string
 		if path != "" {
 			otherSectionTitle = fmt.Sprintf("%s %s", key.OtherSectionTitle, path)

--- a/pkg/generate/row.go
+++ b/pkg/generate/row.go
@@ -27,6 +27,7 @@ type Row struct {
 }
 
 func RowsFromSchema(schema *jsonschema.Schema, path string, name string, keyPatterns []string) []Row {
+	// Sorting happens outside of `RowsFromSchema`, so the order in this slice doesn't matter
 	var rows []Row
 
 	if schema.Ref != nil || schema.RecursiveRef != nil || schema.DynamicRef != nil {


### PR DESCRIPTION
### What does this PR do?

We had unstable ordering in results, and duplicate headings, for example `### Connectivity` if both `.Values.connectivity` and `.Values.global.connectivity` are part of the schema. ~Ensure different titles so that linking works fine, and add some code/comments to ensure sorting is correct and understood for future cases.~ Those should be merged into `.Values.global.*` instead of having dupes. So only the sorting fixes for the code are still in this PR, just to be sure we don't get hit by this in the future.

### What is the effect of this change to users?

~Some headings get the new suffix ` (global)`.~

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
