### PR TITLE
Support loading external schema from URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for loading external schema from URL.
+
 ## [0.0.7] - 2024-04-02
 
 ### Changed

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 
 	pkgerror "github.com/giantswarm/schemadocs/pkg/error"
 	"github.com/giantswarm/schemadocs/pkg/generate/templates"

--- a/pkg/generate/testdata/output_linear.golden
+++ b/pkg/generate/testdata/output_linear.golden
@@ -786,7 +786,7 @@ Tags to select AWS resources for the control plane by.
 
 `.defaultMachinePools.PATTERN.customNodeLabels`
 
-**Type:** `array`
+**Type:** `object`
 
 **Custom node labels**
 
@@ -794,11 +794,11 @@ Tags to select AWS resources for the control plane by.
 
 ---
 
-`.defaultMachinePools.PATTERN.customNodeLabels[*]`
+`.defaultMachinePools.PATTERN.customNodeLabels.PATTERN_2`
 
 **Type:** `string`
 
-**Label**
+**Value of a Kubernetes resource label**
 
 
 
@@ -1048,7 +1048,7 @@ Unique identifier, cannot be changed after creation.
 
 `.nodePools.PATTERN.customNodeLabels`
 
-**Type:** `array`
+**Type:** `object`
 
 **Custom node labels**
 
@@ -1056,11 +1056,11 @@ Unique identifier, cannot be changed after creation.
 
 ---
 
-`.nodePools.PATTERN.customNodeLabels[*]`
+`.nodePools.PATTERN.customNodeLabels.PATTERN_2`
 
 **Type:** `string`
 
-**Label**
+**Value of a Kubernetes resource label**
 
 
 

--- a/pkg/generate/testdata/output_tabular.golden
+++ b/pkg/generate/testdata/output_tabular.golden
@@ -98,8 +98,8 @@ Properties within the `.defaultMachinePools` top-level object
 | `defaultMachinePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `defaultMachinePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `defaultMachinePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
-| `defaultMachinePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
-| `defaultMachinePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
+| `defaultMachinePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
+| `defaultMachinePools.PATTERN.customNodeLabels.PATTERN_2` | **Value of a Kubernetes resource label**|**Type:** `string`<br/>**Examples:** `"exampleValue", "Example_value.with_numbers-and.separators01"`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>`PATTERN_2`=`^[a-zA-Z0-9\._-]+$`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{0,63}$`<br/>|
 | `defaultMachinePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `defaultMachinePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `defaultMachinePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
@@ -148,8 +148,8 @@ Properties within the `.nodePools` top-level object
 | `nodePools.PATTERN` | **Node pool**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `nodePools.PATTERN.availabilityZones` | **Availability zones**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `nodePools.PATTERN.availabilityZones[*]` | **Availability zone**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
-| `nodePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
-| `nodePools.PATTERN.customNodeLabels[*]` | **Label**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
+| `nodePools.PATTERN.customNodeLabels` | **Custom node labels**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
+| `nodePools.PATTERN.customNodeLabels.PATTERN_2` | **Value of a Kubernetes resource label**|**Type:** `string`<br/>**Examples:** `"exampleValue", "Example_value.with_numbers-and.separators01"`<br/>**Key patterns:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>`PATTERN_2`=`^[a-zA-Z0-9\._-]+$`<br/>**Value pattern:** `^[-a-zA-Z0-9_\.]{0,63}$`<br/>|
 | `nodePools.PATTERN.customNodeTaints` | **Custom node taints**|**Type:** `array`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `nodePools.PATTERN.customNodeTaints[*]` |**None**|**Type:** `object`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|
 | `nodePools.PATTERN.customNodeTaints[*].effect` | **Effect**|**Type:** `string`<br/>**Key pattern:**<br/>`PATTERN`=`^[a-z0-9]{5,10}$`<br/>|

--- a/pkg/generate/testdata/schema.json
+++ b/pkg/generate/testdata/schema.json
@@ -19,12 +19,13 @@
           "type": "array"
         },
         "customNodeLabels": {
-          "items": {
-            "title": "Label",
-            "type": "string"
+          "patternProperties": {
+            "^[a-zA-Z0-9\\._-]+$": {
+              "$ref": "https://schema.giantswarm.io/labelvalue/v0.0.1"
+            }
           },
           "title": "Custom node labels",
-          "type": "array"
+          "type": "object"
         },
         "customNodeTaints": {
           "items": {


### PR DESCRIPTION
### What does this PR do?

So far, if the source schema would include a `$ref` to a URL, it would result in this error:

    compilation failed: no Loader found for <schema URL>

This PR adds support for dereferencing external schema URLs.

### What is the effect of this change to users?

Documentation for schema that uses `$ref` pointers to external shcema can be generated.

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
