### PR TITLE
Add precommit hooks for the generate and validate command

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,9 +7,6 @@
   files: \.json$
   require_serial: true
   exclude: ^node_modules/
-  args:
-    - --output-path
-    - README.md
   pass_filenames: true
 
 # validate

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Generate Markdown documentation from JSON Schema
   entry: schemadocs generate
   language: golang
-  files: \.json$
+  files: \.schema\.json$ # Adapt in your own .pre-commit-config.yaml to match your schema files
   require_serial: true
   exclude: ^node_modules/
   pass_filenames: true
@@ -15,10 +15,10 @@
   description: Check whether Markdown documentation for JSON Schema is up-to-date
   entry: schemadocs validate
   language: golang
-  files: README\.md$
+  files: README\.md$ # Adapt in your own .pre-commit-config.yaml to match your markdown file
   require_serial: true
   exclude: ^node_modules/
   pass_filenames: true
   args:
     - --schema
-    - values.schema.json
+    - values.schema.json # Adapt in your own .pre-commit-config.yaml to match your schema file

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,27 @@
+# generate
+- id: schemadocs-generate
+  name: generate schema documentation
+  description: Generate Markdown documentation from JSON Schema
+  entry: schemadocs generate
+  language: golang
+  files: \.json$
+  require_serial: true
+  exclude: ^node_modules/
+  args:
+    - --output-path
+    - README.md
+  pass_filenames: true
+
+# validate
+- id: schemadocs-validate
+  name: validate schema documentation
+  description: Check whether Markdown documentation for JSON Schema is up-to-date
+  entry: schemadocs validate
+  language: golang
+  files: README\.md$
+  require_serial: true
+  exclude: ^node_modules/
+  pass_filenames: true
+  args:
+    - --schema
+    - values.schema.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add [pre-commit](https://pre-commit.com/) hooks
+
 ## [0.0.7] - 2024-04-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/giantswarm/schemadocs/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/giantswarm/schemadocs/tree/main)
 
-# schemadocs - the Giant Swarm JSON Schema docs generator 
+# schemadocs - the Giant Swarm JSON Schema docs generator
 
 schemadocs helps you generate documentation from your JSON schema and store it in README and other documentation files
 
@@ -19,9 +19,9 @@ go install github.com/giantswarm/schemadocs@latest
 
 ### Generating documentation
 
-Executing `schemadocs generate` without any options will generate Markdown documentation from a JSON schema file and store it in a `README.md` file in the current working directory. 
+Executing `schemadocs generate` without any options will generate Markdown documentation from a JSON schema file and store it in a `README.md` file in the current working directory.
 
-It is required that the README file contains exactly one pair of placeholder strings, which mark the start and end of the documentation. 
+It is required that the README file contains exactly one pair of placeholder strings, which mark the start and end of the documentation.
 By default, the placeholders are `<!-- DOCS_START -->` and `<!-- DOCS_END -->`.
 
 If the README file does not exist or in case it does not contain one pair of valid placeholder strings, the execution will fail.
@@ -41,7 +41,10 @@ To generate the documentation to a custom file, apply the `--output-path` option
 To use a pair of custom placeholder strings, apply the `--doc-placeholder-start` and `--doc-placeholder-end`.
 
 ```nohighlight
-$ schemadocs generate schema.json --output-path README.md --doc-placeholder-start <!-- DOCS_START --> --doc-placeholder-end <!-- DOCS_END -->
+schemadocs generate schema.json \
+  --output-path README.md \
+  --doc-placeholder-start <!-- DOCS_START --> \
+  --doc-placeholder-end <!-- DOCS_END -->
 ```
 
 **Note:** The `--doc-placeholder-start` and `--doc-placeholder-end` need to be provided as a pair. So, if one of them is specified, the other one needs to be specified, too.
@@ -72,7 +75,7 @@ Using default placeholders '<!-- DOCS_START -->' and '<!-- DOCS_END -->'
 To use a pair of custom placeholder strings, apply the `--doc-placeholder-start` and `--doc-placeholder-end`.
 
 ```nohighlight
-$ schemadocs validate README.md --schema schema.json --doc-placeholder-start [DOCS_START] --doc-placeholder-end [DOCS_END]
+schemadocs validate README.md --schema schema.json --doc-placeholder-start [DOCS_START] --doc-placeholder-end [DOCS_END]
 ```
 
 **Note:** The `--doc-placeholder-start` and `--doc-placeholder-end` need to be provided as a pair. So, if one of them is specified, the other one needs to be specified, too.


### PR DESCRIPTION
### What does this PR do?

Adds pre-commit hooks to use the `generate` and `validate` commands.

### Do the docs need to be updated?

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)
