### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
             tags:
               only: /^v.*/
       - architect/go-build:
+          context: architect
           name: go-build
           binary: schemadocs
           architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ workflows:
             tags:
               only: /^v.*/
       - architect/upload-release-assets:
+          context: architect
+          binary: schemadocs
           name: upload-release-assets
           requires:
             - go-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.2.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   test:
@@ -10,5 +10,21 @@ workflows:
           name: go-test
           filters:
             # Trigger job also on git tag.
+            tags:
+              only: /^v.*/
+      - architect/go-build:
+          name: go-build
+          binary: schemadocs
+          architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
+          filters:
+            tags:
+              only: /^v.*/
+      - architect/upload-release-assets:
+          name: upload-release-assets
+          requires:
+            - go-build
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `schemadocs-windows-<arch>.exe`.
+
 ## [0.4.0] - 2026-03-03
 
 ### Fixed


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.